### PR TITLE
Update logo images to use Builder.io CDN URLs

### DIFF
--- a/components/layout/footer/Footer2.js
+++ b/components/layout/footer/Footer2.js
@@ -53,7 +53,7 @@ export default function Footer2() {
 								<div className="footer-left">
 									<div className="footer-logo">
 										<Link href="/">
-											<img id="logo_footer" src="/images/logo/footer-logo.png" data-retina="./images/logo/footer-logo@2x.png" alt="occws" />
+											<img id="logo_footer" src="https://cdn.builder.io/api/v1/image/assets%2Fab3018047d0c4b508dd0b16003d9a634%2F533d51780c52493abea07782a32fa659" data-retina="./images/logo/footer-logo@2x.png" alt="occws" />
 										</Link>
 									</div>
 									<p className="description">We provide a safe space where you can find peace within yourself.

--- a/components/layout/header/Header4.js
+++ b/components/layout/header/Header4.js
@@ -21,7 +21,7 @@ export default function Header4({ scroll, isMobileMenu, handleMobileMenu }) {
 					</div>
 					<div className="top-logo">
 						<Link href="/" className="site-logo">
-							<img alt="occws" src="/images/logo/Logo.png" />
+							<img alt="occws" src="https://cdn.builder.io/api/v1/image/assets%2Fab3018047d0c4b508dd0b16003d9a634%2F533d51780c52493abea07782a32fa659" />
 						</Link>
 					</div>
 					<div className="top-bar-right">
@@ -127,7 +127,7 @@ export default function Header4({ scroll, isMobileMenu, handleMobileMenu }) {
 						<div className="header-left">
 							<div className="header-logo-2">
 								<Link href="/" className="site-logo">
-									<img id="logo_header" alt="occws" src="/images/logo/Logo.png" data-retina="images/logo/logo@2x.png" />
+									<img id="logo_header" alt="occws" src="https://cdn.builder.io/api/v1/image/assets%2Fab3018047d0c4b508dd0b16003d9a634%2F533d51780c52493abea07782a32fa659" data-retina="images/logo/logo@2x.png" />
 								</Link>
 							</div>
 							<nav className="main-menu mx-0">
@@ -135,7 +135,7 @@ export default function Header4({ scroll, isMobileMenu, handleMobileMenu }) {
 							</nav>
 							<div className="header-logo">
 								<Link href="/" className="site-logo">
-									<img id="logo_header" alt="occws" src="/images/logo/Logo.png" data-retina="images/logo/logo@2x.png" />
+									<img id="logo_header" alt="occws" src="https://cdn.builder.io/api/v1/image/assets%2Fab3018047d0c4b508dd0b16003d9a634%2F533d51780c52493abea07782a32fa659" data-retina="images/logo/logo@2x.png" />
 								</Link>
 							</div>
 						</div>


### PR DESCRIPTION
## Purpose
The user requested visual changes to update logo image sources in the footer and header components to use a CDN-hosted version instead of local assets.

## Code changes
- **Footer2.js**: Updated footer logo image source from local path `/images/logo/footer-logo.png` to Builder.io CDN URL
- **Header4.js**: Updated all header logo image sources (4 instances) from local path `/images/logo/Logo.png` to the same Builder.io CDN URL
- All logo images now point to: `https://cdn.builder.io/api/v1/image/assets%2Fab3018047d0c4b508dd0b16003d9a634%2F533d51780c52493abea07782a32fa659`
- Retina image fallbacks and alt text remain unchanged

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/febfa9b9e1124d1998a74c08de11ef86/pulse-studio)

👀 [Preview Link](https://febfa9b9e1124d1998a74c08de11ef86-pulse-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>febfa9b9e1124d1998a74c08de11ef86</projectId>-->
<!--<branchName>pulse-studio</branchName>-->